### PR TITLE
fix: MESSAGE_CONTEXT_MENU,  USER_CONTEXT_MENU, and SELECT_MENU

### DIFF
--- a/src/types/discord.ts
+++ b/src/types/discord.ts
@@ -28,7 +28,6 @@ export type Command =
           run: (interaction: MessageContextMenuCommandInteraction) => unknown;
           name: string;
           name_localizations?: Record<string, string>;
-          description: string;
           description_localizations?: Record<string, string>;
           options?: ApplicationCommandOption[];
           default_member_permissions?: string;
@@ -41,7 +40,6 @@ export type Command =
           run: (interaction: UserContextMenuCommandInteraction) => unknown;
           name: string;
           name_localizations?: Record<string, string>;
-          description: string;
           description_localizations?: Record<string, string>;
           options?: ApplicationCommandOption[];
           default_member_permissions?: string;

--- a/src/types/discord.ts
+++ b/src/types/discord.ts
@@ -7,6 +7,7 @@ import type {
     MessageContextMenuCommandInteraction,
     ModalSubmitInteraction,
     UserContextMenuCommandInteraction,
+    StringSelectMenuInteraction,
 } from "discord.js";
 
 export type Command =
@@ -50,7 +51,7 @@ export type Command =
     | {
           role: "SELECT_MENU";
           custom_id: string;
-          run: (interaction: AnySelectMenuInteraction) => unknown;
+          run: (interaction: StringSelectMenuInteraction) => unknown;
       }
     | {
           role: "BUTTON";


### PR DESCRIPTION
- Updated to use `StringSelectMenuInteraction` for the `SELECT_MENU` role.
- Removed the description field from `MESSAGE_CONTEXT_MENU` and `USER_CONTEXT_MENU` because they cannot have descriptions